### PR TITLE
Changed client name for easy counting of nodes

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -13,7 +13,7 @@
  * for both bitcoind and bitcoin-core, to make it harder for attackers to
  * target servers or GUI users specifically.
  */
-const std::string CLIENT_NAME("Bitcoin Gold");
+const std::string CLIENT_NAME("realBitcoinGold");
 
 /**
  * Client version number


### PR DESCRIPTION
Changed client name to make it easy to track realBitcoinGold nodes on the network.

https://bitnodes.21.co/nodes/?q=realBitcoinGold